### PR TITLE
fix: #35 dice rolling animation issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -53,10 +53,9 @@ If applicable, add screenshots to help explain your problem.
 
 ## 🖥 Desktop or Smartphone
 
-- Device: [e.g. iPhone6]
 - OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
+- Browser: [e.g. chrome, safari]
+- Device: [e.g. iPhone6]
 
 ## 📄 Additional context
 

--- a/lib/routes/Dice/DiceRoute.tsx
+++ b/lib/routes/Dice/DiceRoute.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
   useTheme,
 } from "@material-ui/core";
-import { css } from "emotion";
+import { css, cx } from "emotion";
 import React, { useState } from "react";
 import { Page } from "../../components/Page/Page";
 import { PageMeta } from "../../components/PageMeta/PageMeta";
@@ -31,6 +31,27 @@ export const DiceRoute = () => {
     });
   }
 
+  const diceStyle = css({
+    fontSize: "5rem",
+    lineHeight: Font.lineHeight(5),
+    color: diceManager.state.color,
+    background: highlightBackgroundColor,
+    border: `.5rem solid ${theme.palette.primary.main}`,
+    borderRadius: "4px",
+    width: "7rem",
+    height: "7rem",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    boxShadow:
+      "3px 5px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12)",
+  });
+  const diceRollingAnimationStyle = css({
+    animationName: "spin",
+    animationDuration: "250ms",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "linear",
+  });
   return (
     <Page>
       <PageMeta
@@ -64,24 +85,8 @@ export const DiceRoute = () => {
         <Box display="flex" justifyContent="center" pt="3rem">
           <Tooltip title={diceManager.state.tooltip}>
             <Typography
-              className={css({
-                fontSize: "5rem",
-                lineHeight: Font.lineHeight(5),
-                color: diceManager.state.color,
-                background: highlightBackgroundColor,
-                border: `.5rem solid ${theme.palette.primary.main}`,
-                borderRadius: "4px",
-                width: "7rem",
-                height: "7rem",
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                boxShadow:
-                  "3px 5px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12)",
-                animationName: diceManager.state.rolling ? "spin" : undefined,
-                animationDuration: "250ms",
-                animationIterationCount: "infinite",
-                animationTimingFunction: "linear",
+              className={cx(diceStyle, {
+                [diceRollingAnimationStyle]: diceManager.state.rolling,
               })}
             >
               {diceManager.state.label}

--- a/lib/routes/Play/components/PlayerRow.tsx
+++ b/lib/routes/Play/components/PlayerRow.tsx
@@ -50,17 +50,37 @@ export const PlayerRow: React.FC<{
     backgroundColor: shouldHighlight ? highlightBackgroundColor : "transparent",
     color: shouldHighlight ? textColor.primary : undefined,
   });
-  const firstRowTableCellStyle = css({
+  const playerInfoRowStyle = css({
     padding: "0.7rem",
     borderBottom: "none",
   });
-  const secondRowTableCellStyle = css({
+  const controlsRowStyle = css({
     padding: "0 0.5rem",
+  });
+  const diceStyle = css({
+    fontSize: "1.2rem",
+    lineHeight: Font.lineHeight(1.2),
+    color: diceManager.state.color,
+    border: `.1rem solid ${theme.palette.primary.main}`,
+    width: "2rem",
+    borderRadius: "4px",
+    height: "2rem",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    boxShadow:
+      "2px 2px 2px 0px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12)",
+  });
+  const diceRollingAnimationStyle = css({
+    animationName: "spin",
+    animationDuration: "250ms",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "linear",
   });
   return (
     <>
       <TableRow className={rowStyle}>
-        <TableCell className={firstRowTableCellStyle} align="left">
+        <TableCell className={playerInfoRowStyle} align="left">
           <Typography
             noWrap
             className={css({
@@ -71,7 +91,7 @@ export const PlayerRow: React.FC<{
             {t(props.player.playerName as IPossibleTranslationKeys)}
           </Typography>
         </TableCell>
-        <TableCell className={firstRowTableCellStyle} align="center">
+        <TableCell className={playerInfoRowStyle} align="center">
           <Tooltip
             title={
               props.player.playedDuringTurn
@@ -102,37 +122,20 @@ export const PlayerRow: React.FC<{
             </span>
           </Tooltip>
         </TableCell>
-        <TableCell className={cx(firstRowTableCellStyle)} align="center">
+        <TableCell className={cx(playerInfoRowStyle)} align="center">
           <Tooltip title={t("player-row.fate-points")}>
             <Badge badgeContent={props.player.fatePoints} color="primary">
               <FlareIcon width="2"></FlareIcon>
             </Badge>
           </Tooltip>
         </TableCell>
-        <TableCell className={cx(firstRowTableCellStyle)} align="right">
+        <TableCell className={cx(playerInfoRowStyle)} align="right">
           {shouldRenderDiceResult && (
             <Box display="flex" justifyContent="flex-end">
               <Tooltip title={diceManager.state.tooltip}>
                 <Typography
-                  className={css({
-                    fontSize: "1.2rem",
-                    lineHeight: Font.lineHeight(1.2),
-                    color: diceManager.state.color,
-                    border: `.1rem solid ${theme.palette.primary.main}`,
-                    width: "2rem",
-                    borderRadius: "4px",
-                    height: "2rem",
-                    display: "flex",
-                    justifyContent: "center",
-                    alignItems: "center",
-                    boxShadow:
-                      "2px 2px 2px 0px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12)",
-                    animationName: diceManager.state.rolling
-                      ? "spin"
-                      : undefined,
-                    animationDuration: "250ms",
-                    animationIterationCount: "infinite",
-                    animationTimingFunction: "linear",
+                  className={cx(diceStyle, {
+                    [diceRollingAnimationStyle]: diceManager.state.rolling,
                   })}
                 >
                   {diceManager.state.label}
@@ -143,7 +146,7 @@ export const PlayerRow: React.FC<{
         </TableCell>
       </TableRow>
       {props.isGM && (
-        <TableRow className={cx(rowStyle, secondRowTableCellStyle)}>
+        <TableRow className={cx(rowStyle, controlsRowStyle)}>
           <TableCell colSpan={4}>
             <Grid container alignItems="center" justify="flex-end" spacing={1}>
               <Grid item>


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: #35 dice rolling animation issue

## 🌄 Context

<!-- Provide more context around why this pull requests was created -->

Seems like emotion is having trouble properly updating the animation property when you are not focused on the tab that has an animated object.

I refactored the code to simply "remove" the css class when it needs to stop animating

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
